### PR TITLE
Issue #31, provide option to reset the list so all items are unchecked

### DIFF
--- a/app/src/main/java/com/lolo/io/onelist/OneListFragment.kt
+++ b/app/src/main/java/com/lolo/io/onelist/OneListFragment.kt
@@ -112,6 +112,7 @@ class OneListFragment : Fragment(), ListsCallbacks, ItemsCallbacks, MainActivity
         buttonAddComment.setOnClickListener { switchCommentSection() }
         buttonClearComment.setOnClickListener { addCommentEditText.text.clear() }
         buttonShareList.setOnClickListener { persistence.shareList(selectedList) }
+        buttonRestartList.setOnClickListener { restartList() }
 
         menu_arrow.setOnTouchListener { v, e ->
             if (e.action == MotionEvent.ACTION_DOWN) {
@@ -387,6 +388,20 @@ class OneListFragment : Fragment(), ListsCallbacks, ItemsCallbacks, MainActivity
         persistence.saveListAsync(selectedList)
     }
 
+    private fun restartList() {
+        var updatedAnyItems = false
+        for ((index, item) in selectedList.items.withIndex()) {
+            if (item.done) {
+                item.done = false
+                itemsAdapter.notifyItemChanged(index)
+                updatedAnyItems = true
+            }
+        }
+        if (updatedAnyItems) {
+            persistence.saveListAsync(selectedList)
+        }
+    }
+
     override fun onShowOrHideComment(item: Item) {
         item.commentDisplayed = !item.commentDisplayed
         itemsAdapter.notifyItemChanged(selectedList.items.indexOf(item))
@@ -432,6 +447,7 @@ class OneListFragment : Fragment(), ListsCallbacks, ItemsCallbacks, MainActivity
 
     private fun showEditionButtons() {
         buttonShareList.visibility = View.GONE
+        buttonRestartList.visibility = View.GONE
         buttonRemoveList.animShowFlip()
         buttonAddList.animHideFlip(startDelay = BUTTON_ANIM_DURATION)
         buttonEditList.animShowFlip()
@@ -440,6 +456,7 @@ class OneListFragment : Fragment(), ListsCallbacks, ItemsCallbacks, MainActivity
 
     private fun hideEditionButtons() {
         buttonShareList.visibility = View.VISIBLE
+        buttonRestartList.visibility = View.VISIBLE
         buttonAddList.animShowFlip()
         buttonRemoveList.animHideFlip(startDelay = BUTTON_ANIM_DURATION)
         buttonEditList.animHideFlip()

--- a/app/src/main/res/drawable/ic_baseline_restore_page_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_restore_page_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@color/textColorPrimary"
+      android:pathData="M14,2L6,2c-1.1,0 -1.99,0.9 -1.99,2L4,20c0,1.1 0.89,2 1.99,2L18,22c1.1,0 2,-0.9 2,-2L20,8l-6,-6zM12,18c-2.05,0 -3.81,-1.24 -4.58,-3h1.71c0.63,0.9 1.68,1.5 2.87,1.5 1.93,0 3.5,-1.57 3.5,-3.5S13.93,9.5 12,9.5c-1.35,0 -2.52,0.78 -3.1,1.9l1.6,1.6h-4L6.5,9l1.3,1.3C8.69,8.92 10.23,8 12,8c2.76,0 5,2.24 5,5s-2.24,5 -5,5z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_one_list.xml
+++ b/app/src/main/res/layout/fragment_one_list.xml
@@ -139,6 +139,19 @@
                         android:scaleY="0.8"
                         app:srcCompat="@drawable/ic_share_black_24dp" />
 
+                    <ImageButton
+                        android:id="@+id/buttonRestartList"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentEnd="true"
+                        android:layout_alignParentRight="true"
+                        android:layout_marginEnd="64dp"
+                        android:layout_marginRight="64dp"
+                        android:background="?attr/selectableItemBackground"
+                        android:contentDescription="@string/add_list"
+                        android:padding="5dp"
+                        app:srcCompat="@drawable/ic_baseline_restore_page_24" />
+
                 </RelativeLayout>
 
             </RelativeLayout>


### PR DESCRIPTION
This provides a simple solution to the "uncheck" part of the issue by adding a button next to the 'share' button, which will reset the checked status of all items. It does nothing special with the order of the items, simply unchecking them all. I've done this for my own use as it's functionality that I need nearly daily, so thought I would share.

I've used one of the icons providing by Android Studio for importing into projects which works for me but may not fit with overall design goals of @lolo-io.

It's also my first time with Kotlin.